### PR TITLE
docs: rewrite README for Azhura portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,52 @@
-# Nuxt Minimal Starter
+# Azhura
 
-Look at the [Nuxt documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.
+Personal portfolio site built with Nuxt 4, Bun, and MySQL.
+
+## Stack
+
+- **Framework:** [Nuxt 4](https://nuxt.com/docs/getting-started/introduction)
+- **Runtime:** [Bun](https://bun.sh/)
+- **Database:** MySQL via [Drizzle ORM](https://orm.drizzle.team/) (`mysql2` driver)
+- **Styling:** TailwindCSS v4
+- **Validation:** VeeValidate + Zod (`drizzle-zod`, `@vee-validate/zod`)
 
 ## Setup
 
-Make sure to install dependencies:
+Install dependencies:
 
 ```bash
-# npm
-npm install
-
-# pnpm
-pnpm install
-
-# yarn
-yarn install
-
-# bun
 bun install
 ```
 
-## Development Server
+Configure environment variables (create a `.env` file) for the MySQL connection used by Drizzle — see [drizzle.config.ts](drizzle.config.ts).
 
-Start the development server on `http://localhost:3000`:
+## Development
+
+Start the dev server on `http://localhost:3000`:
 
 ```bash
-# npm
-npm run dev
-
-# pnpm
-pnpm dev
-
-# yarn
-yarn dev
-
-# bun
 bun run dev
+```
+
+## Database
+
+Drizzle scripts:
+
+```bash
+bun run db:generate   # generate migrations from schema
+bun run db:migrate    # apply migrations
+bun run db:seed       # seed initial data
+bun run db:reset      # reset the database
+bun run db:studio     # open Drizzle Studio
 ```
 
 ## Production
 
-Build the application for production:
+Build and preview:
 
 ```bash
-# npm
-npm run build
-
-# pnpm
-pnpm build
-
-# yarn
-yarn build
-
-# bun
 bun run build
-```
-
-Locally preview production build:
-
-```bash
-# npm
-npm run preview
-
-# pnpm
-pnpm preview
-
-# yarn
-yarn preview
-
-# bun
 bun run preview
 ```
 
-Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+See the [Nuxt deployment docs](https://nuxt.com/docs/getting-started/deployment) for hosting options.


### PR DESCRIPTION
## Summary
- Replace default Nuxt starter README with content describing the actual project: Azhura portfolio site.
- Document the real stack (Nuxt 4, Bun, MySQL via Drizzle, Tailwind v4, VeeValidate + Zod) and Bun-only commands.
- Add a Database section listing the `db:*` scripts that already exist in `package.json`.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all referenced files exist (`drizzle.config.ts`, `package.json` scripts)
- [ ] Confirm external links resolve (Nuxt docs, Bun, Drizzle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)